### PR TITLE
feat: init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,25 +23,66 @@ yarn add resumefy jsonresume-theme-even # or your theme of choice
 
 ## Usage
 
-You can render your resume by running the command `resumefy [resume.json]`, where `[resume.json]` is the path to your JSON resume file. If no file path is provided, it will look for a `resume.json` in the current directory. The following options can be used.
+Resumefy provides two commands, `render` and `init`, which can be used in the following way.
 
 ```shell
 $ resumefy --help
 
-  Usage: resumefy [options] [resume.json]
+  Usage: resumefy [options] [command]
 
   A CLI for effortlessly rendering your JSON Resume
+
+  Options:
+    -V, --version                   output the version number
+    -h, --help                      display help for command
+
+  Commands:
+    render [options] [resume.json]  render resume to PDF and HTML
+    init [options] [resume.json]    create a new resume.json file
+    help [command]                  display help for command
+```
+
+## Commands
+
+### `render` (default)
+
+Renders resume in a browser window and exports it to HTML and PDF. The `[resume.json]` argument specifies the path to your JSON resume file. If no file path is provided, it defaults to `resume.json` in the current directory. The following options are available:
+
+```shell
+$ resumefy render --help
+
+  Usage: resumefy render [options] [resume.json]
+
+  render resume to PDF and HTML
 
   Arguments:
     resume.json            path to resume JSON file (default: "resume.json")
 
   Options:
-    -V, --version          output the version number
     -d, --outDir <outDir>  directory to save output files (default: "result")
     -t, --theme <theme>    theme to use for rendering (overrides theme specified in resume.json)
     -w, --watch            watch resume.json file for changes
     --headless             run browser in headless mode
     -h, --help             display help for command
+```
+
+### `init`
+
+Creates a new resume JSON file with sample data. The `[resume.json]` argument specifies the file name. The following options are available:
+
+```shell
+$ resumefy init --help
+
+  Usage: resumefy init [options] [resume.json]
+
+  create a new resume.json file
+
+  Arguments:
+    resume.json          filename to create (default: "resume.json")
+
+  Options:
+    -t, --theme <theme>  theme to use for rendering (sets theme in resume.json)
+    -h, --help           display help for command
 ```
 
 ### Theme resolution

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,6 @@ cli
 cli
   .command('init')
   .description('create a new resume.json file')
-  .argument('[filename]', 'filename to create', 'resume.json')
+  .argument('[resume.json]', 'filename to create', 'resume.json')
   .option('-t, --theme <theme>', 'theme to use for rendering (sets theme in resume.json)')
   .action((filename: string = 'resume.json', options: InitOptions) => init(filename, options))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,21 +1,23 @@
 import { program } from 'commander'
 import { render } from './render/index.js'
+import { InitOptions, RenderOptions } from './types.js'
+import { init } from './init.js'
 
-export type CliOptions = {
-  outDir: string
-  theme: string
-  watch?: boolean
-  headless?: boolean
-}
+export const cli = program.version('1.1.0').description('A CLI for effortlessly rendering your JSON Resume')
 
-export const cli = program
-  .version('1.1.0')
-  .description('A CLI for effortlessly rendering your JSON Resume')
+cli
+  .command('render', { isDefault: true })
+  .description('render resume to PDF and HTML')
   .argument('[resume.json]', 'path to resume JSON file', 'resume.json')
   .option('-d, --outDir <outDir>', 'directory to save output files', 'result')
   .option('-t, --theme <theme>', 'theme to use for rendering (overrides theme specified in resume.json)')
   .option('-w, --watch', 'watch resume.json file for changes')
   .option('--headless', 'run browser in headless mode')
-  .action(async (filename: string = 'resume.json', { outDir, theme, watch, headless }: CliOptions) =>
-    render(filename, { outDir, watch, headless, theme }),
-  )
+  .action((filename: string = 'resume.json', options: RenderOptions) => render(filename, options))
+
+cli
+  .command('init')
+  .description('create a new resume.json file')
+  .argument('[filename]', 'filename to create', 'resume.json')
+  .option('-t, --theme <theme>', 'theme to use for rendering (sets theme in resume.json)')
+  .action((filename: string = 'resume.json', options: InitOptions) => init(filename, options))

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,23 @@
+import sampleResume from '@jsonresume/schema/sample.resume.json' with { type: 'json' }
+import { promises as fs } from 'fs'
+import { InitOptions } from './types.js'
+import { getTheme } from './render/utils.js'
+
+export const init = async (filename: string, options: InitOptions) => {
+  const { theme } = options
+
+  if (theme) {
+    try {
+      await getTheme(theme)
+    } catch (err) {
+      if (err instanceof Error) {
+        console.warn(err.message)
+      }
+    }
+  }
+
+  const resume = theme ? { ...sampleResume, meta: { ...sampleResume.meta, theme } } : sampleResume
+
+  await fs.writeFile(filename, JSON.stringify(resume, null, 2))
+  console.log('🚀', `Created file ${filename}`)
+}

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -3,17 +3,7 @@ import puppeteer from 'puppeteer'
 import { generateHtml, loadFile, printSuccess, renderError, renderPage, validateResume, writeFiles } from './steps.js'
 import { ResumeBrowser } from '../browser/index.js'
 import { getFilename } from './utils.js'
-
-export type RenderOptions = {
-  // Directory to save output files
-  outDir?: string
-  // Run browser in headless mode
-  headless?: boolean
-  // Watch resume file for changes
-  watch?: boolean
-  // Theme name to use
-  theme?: string
-}
+import { RenderOptions } from '../types.js'
 
 /**
  * Render resume in browser and save PDF and HTML files.

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,3 +7,19 @@ export interface Resume {
     theme?: string
   }
 }
+
+export type RenderOptions = {
+  // Directory to save output files
+  outDir?: string
+  // Run browser in headless mode
+  headless?: boolean
+  // Watch resume file for changes
+  watch?: boolean
+  // Theme name to use
+  theme?: string
+}
+
+export type InitOptions = {
+  // Theme name to use
+  theme?: string
+}


### PR DESCRIPTION
This pull request introduces significant updates to the `resumefy` CLI, including the addition of a new `init` command, refactoring of options and types, and improvements to the code structure. Here are the most important changes:

### New Command Addition:

* Added a new `init` command to create a new resume JSON file with sample data. This command includes options for specifying the theme. (`README.md`, `src/cli.ts`, `src/init.ts`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R87) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR3-R23) [[3]](diffhunk://#diff-0e586e6c3496396d18792bb5dfc86ecfb5dd0fd43f81f33e55672bb2bee2ae79R1-R23)

### Refactoring:

* Refactored the `render` command to use the new `RenderOptions` type, improving code clarity and maintainability. (`src/cli.ts`, `src/render/index.ts`, `src/types.ts`) [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR3-R23) [[2]](diffhunk://#diff-eb8f63cd7e3c28d767a94232f636e75ef2ee2ba15aa214a17d6b3b69c08f982bL6-R6) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR10-R25)

### Documentation:

* Updated the `README.md` to reflect the changes in the CLI commands, including detailed usage instructions for both `render` and `init` commands. (`README.md`)