### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resumefy",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resumefy",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@jsonresume/schema": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resumefy",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A CLI for effortlessly rendering your JSON Resume",
   "keywords": [
     "resume",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,15 @@
     "bin",
     "dist"
   ],
+  "dependencies": {
+    "@jsonresume/schema": "^1.2.1",
+    "ansicolor": "^2.0.3",
+    "commander": "^13.0.0",
+    "error-html": "^0.3.5",
+    "jsonschema": "^1.5.0",
+    "puppeteer": "^24.0.0",
+    "resumed": "^4.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@types/node": "^22.10.5",
@@ -40,15 +49,5 @@
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.19.1"
-  },
-  "dependencies": {
-    "@jsonresume/schema": "^1.2.1",
-    "@tmjssz/jsonresume-theme-even": "^0.4.1",
-    "ansicolor": "^2.0.3",
-    "commander": "^13.0.0",
-    "error-html": "^0.3.5",
-    "jsonschema": "^1.5.0",
-    "puppeteer": "^24.0.0",
-    "resumed": "^4.0.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { render } from './render/index.js'
 import { InitOptions, RenderOptions } from './types.js'
 import { init } from './init.js'
 
-export const cli = program.version('1.1.0').description('A CLI for effortlessly rendering your JSON Resume')
+export const cli = program.version('1.2.0').description('A CLI for effortlessly rendering your JSON Resume')
 
 cli
   .command('render', { isDefault: true })


### PR DESCRIPTION
This pull request includes version updates to the `resumefy` project to reflect the new version 1.2.0.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the project version from `1.1.0` to `1.2.0`.
* [`src/cli.ts`](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL6-R6): Updated the CLI version from `1.1.0` to `1.2.0`.