### PR TITLE
chore: add GitHub Actions workflow for publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,17 +2,8 @@ name: Publish to npmjs
 
 on:
   # Trigger the workflow when a new release is created
-  #   release:
-  #     types: [created]
-
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  release:
+    types: [created]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to npmjs
+
+on:
+  # Trigger the workflow when a new release is created
+  #   release:
+  #     types: [created]
+
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        id: install
+        run: npm ci
+
+      - name: Build package
+        id: build
+        run: npm run build
+
+      - name: Publish package
+        id: publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "employment"
   ],
   "type": "module",
-  "repository": "https://github.com/tmjssz/resumefy",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tmjssz/resumefy.git"
+  },
   "author": "Tim-Jonas Schwarz <tmjssz@gmail.com>",
   "license": "MIT",
   "private": false,
@@ -26,7 +29,9 @@
     "start": "node --import=tsx src/index.ts",
     "lint": "eslint src"
   },
-  "bin": "./bin/resumefy.js",
+  "bin": {
+    "resumefy": "bin/resumefy.js"
+  },
   "files": [
     "bin",
     "dist"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing to npm and updates the `package.json` file to improve repository and binary configuration.

### New GitHub Actions Workflow:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R38): Added a new workflow to automate publishing to npm when a new release is created. This includes steps for checking out the repository, setting up Node.js, installing dependencies, building the package, and publishing it to npm.

### Updates to `package.json`:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R20): Changed the repository field to an object with `type` and `url` for better clarity and compatibility with npm.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R34): Updated the `bin` field to an object to specify the binary name and path more explicitly.