### PR TITLE
chore: prepare release 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resumefy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resumefy",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@jsonresume/schema": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resumefy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A simple toolkit to bring your JSON Resume to life",
   "keywords": [
     "resume",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@ import { render } from './render.js'
 import { init } from './init.js'
 import { validate } from './validate.js'
 
-export const cli = program.version('1.3.0').description('A simple toolkit to bring your JSON Resume to life')
+export const cli = program.version('1.4.0').description('A simple toolkit to bring your JSON Resume to life')
 
 cli
   .command('render', { isDefault: true })


### PR DESCRIPTION
This pull request includes updates to the version number of the `resumefy` package to reflect a new release.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.3.0` to `1.4.0` to indicate a new release.
* [`src/cli/index.ts`](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2L6-R6): Updated the CLI version from `1.3.0` to `1.4.0` to match the new release version.