### PR TITLE
chore: remove unnecessary permissions from GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,6 @@ jobs:
           - branch: ${{ github.head_ref }}
             artifact: pull-request
 
-    permissions:
-      # Required to checkout the code
-      contents: read
-
     steps:
       - name: Checkout
         id: checkout


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/test.yml` file. The change removes the `permissions` section, which was previously required to checkout the code. 

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L25-L28): Removed the `permissions` section that was required to checkout the code.