### PR TITLE
chore: add Dependabot configuration for npm and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: 'npm'
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: '/'
+    # Check the npm registry for updates every week
+    schedule:
+      interval: 'weekly'
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
This pull request introduces a configuration file for Dependabot to automate dependency updates for npm packages and GitHub Actions workflows. The most important changes include specifying the package ecosystems to update, defining the directories to search for package manifests, and setting the update schedule.

Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R22): Added configuration to enable version updates for npm packages and GitHub Actions workflows, specifying the directories to look for `package.json` and workflow files, and setting the update interval to weekly.