### PR TITLE
fix: update publish command to use npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Publish package
         id: publish
-        run: yarn publish
+        run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change modifies the command used to publish the package from `yarn publish` to `yarn npm publish`.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L36-R36): Changed the `run` command from `yarn publish` to `yarn npm publish` in the `Publish package` job to ensure the correct publishing process is used.