### PR TITLE
fix: publish workflow followup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: yarn
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         id: install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: yarn
+          registry-url: 'https://registry.npmjs.org'
 
       # ESLint and Prettier must be in `package.json`
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,7 @@ on:
   # Trigger the workflow when a new release is created
   release:
     types: [created]
-  pull_request:
-      branches:
-        - main
+
 jobs:
   publish:
     name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,9 @@ on:
   # Trigger the workflow when a new release is created
   release:
     types: [created]
-
+  pull_request:
+      branches:
+        - main
 jobs:
   publish:
     name: Publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: yarn
+          registry-url: 'https://registry.npmjs.org'
 
       # ESLint and Prettier must be in `package.json`
       - name: Install dependencies

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: yarn
+          registry-url: 'https://registry.npmjs.org'
 
       # ESLint and Prettier must be in `package.json`
       - name: Install dependencies

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
+
+npmAuthToken: ${NPM_TOKEN}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
 
 npmAuthToken: ${secrets.NPM_TOKEN}
+
+npmPublishRegistry: https://registry.npmjs.org

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,4 +2,4 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
 
-npmAuthToken: ${NPM_AUTH_TOKEN}
+npmAuthToken: ${secrets.NPM_TOKEN}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,6 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
 
-npmAuthToken: ${secrets.NPM_TOKEN}
+npmAuthToken: ${NODE_AUTH_TOKEN}
 
 npmPublishRegistry: https://registry.npmjs.org

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,4 +2,4 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
 
-npmAuthToken: ${NPM_TOKEN}
+npmAuthToken: ${NPM_AUTH_TOKEN}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows and the Yarn configuration file to ensure proper registry and authentication settings.

GitHub Actions workflow updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R29): Added `registry-url` to the `jobs:` section to specify the npm registry URL.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R29): Added `registry-url` to the `jobs:` section to specify the npm registry URL.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R25): Added `registry-url` to the `jobs:` section to specify the npm registry URL.
* [`.github/workflows/test_pull_request.yml`](diffhunk://#diff-e31e36a64c0b565f16afc3f9df9502612e1dcc465126db1fd4032d7022950a06R32): Added `registry-url` to the `jobs:` section to specify the npm registry URL.

Yarn configuration update:

* [`.yarnrc.yml`](diffhunk://#diff-88fbe28c4102501b94961511a0d70ff895bf39970b4d3fc11917794a239117c5R4-R7): Added `npmAuthToken` and `npmPublishRegistry` to configure npm authentication and registry settings.