### PR TITLE
fix: add .env variable for npm auth token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Auth token for publishing to npmjs.org
+NODE_AUTH_TOKEN='<NODE_AUTH_TOKEN>'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ coverage/
 
 sample.resume.*
 
+.env
+
 # TypeScript cache
 *.tsbuildinfo
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,4 @@ npmAuthToken: ${NODE_AUTH_TOKEN:-}
 
 npmPublishRegistry: https://registry.npmjs.org
 
-injectEnvironmentFiles: ['.env']
+injectEnvironmentFiles: ['.env?']

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,6 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
 
-npmAuthToken: ${NODE_AUTH_TOKEN}
+npmAuthToken: ${NODE_AUTH_TOKEN:-}
 
 npmPublishRegistry: https://registry.npmjs.org

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ yarnPath: .yarn/releases/yarn-4.6.0.cjs
 npmAuthToken: ${NODE_AUTH_TOKEN:-}
 
 npmPublishRegistry: https://registry.npmjs.org
+
+injectEnvironmentFiles: ['.env']


### PR DESCRIPTION
This pull request includes changes to the configuration files for managing environment variables and publishing to npm. The most important changes include adding an authentication token placeholder to the `.env.example` file and updating the `.yarnrc.yml` configuration to ensure environment variables are injected correctly.

Configuration changes:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R2): Added a placeholder for the `NODE_AUTH_TOKEN` to be used for publishing to npmjs.org.
* [`.yarnrc.yml`](diffhunk://#diff-88fbe28c4102501b94961511a0d70ff895bf39970b4d3fc11917794a239117c5L5-R9): Updated the `npmAuthToken` to use a default value if `NODE_AUTH_TOKEN` is not set, and added `injectEnvironmentFiles` to include the `.env` file.