### PR TITLE
chore: dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![build status](https://github.com/tmjssz/resumefy/actions/workflows/build.yml/badge.svg)](https://github.com/tmjssz/resumefy/actions/workflows/build.yml?query=branch%3Amain)
 [![coverage](https://tmjssz.github.io/resumefy/badges/coverage.svg)](https://github.com/tmjssz/resumefy/actions/workflows/test.yml?query=branch%3Amain)
 ![dependency status](https://img.shields.io/librariesio/github/tmjssz/resumefy)
+[![Dependabot](https://badgen.net/badge/Dependabot/enabled/green?icon=dependabot)](https://dependabot.com/)
 ![Node Current](https://img.shields.io/node/v/resumefy)
 
 > A simple toolkit to bring your [JSON Resume](https://jsonresume.org/) to life

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![NPM Version](https://img.shields.io/npm/v/resumefy)](https://www.npmjs.com/package/resumefy)
 [![build status](https://github.com/tmjssz/resumefy/actions/workflows/build.yml/badge.svg)](https://github.com/tmjssz/resumefy/actions/workflows/build.yml?query=branch%3Amain)
 [![coverage](https://tmjssz.github.io/resumefy/badges/coverage.svg)](https://github.com/tmjssz/resumefy/actions/workflows/test.yml?query=branch%3Amain)
+![Node Current](https://img.shields.io/node/v/resumefy)
 ![dependency status](https://img.shields.io/librariesio/github/tmjssz/resumefy)
 [![Dependabot](https://badgen.net/badge/Dependabot/enabled/green?icon=dependabot)](https://dependabot.com/)
-![Node Current](https://img.shields.io/node/v/resumefy)
 
 > A simple toolkit to bring your [JSON Resume](https://jsonresume.org/) to life
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@tmjssz/jsonresume-theme-even": "^0.4.1",
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.5",
-    "@vitest/coverage-v8": "^3.0.4",
+    "@vitest/coverage-v8": "^3.0.5",
     "eslint": "^9.18.0",
     "globals": "^15.14.0",
     "prettier": "^3.4.2",
@@ -68,7 +68,7 @@
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.19.1",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.5"
   },
   "packageManager": "yarn@4.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@tmjssz/jsonresume-theme-even": "^0.4.1",
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.5",
-    "@vitest/coverage-v8": "3.0.4",
+    "@vitest/coverage-v8": "^3.0.4",
     "eslint": "^9.18.0",
     "globals": "^15.14.0",
     "prettier": "^3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,9 +1079,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:3.0.4":
-  version: 3.0.4
-  resolution: "@vitest/coverage-v8@npm:3.0.4"
+"@vitest/coverage-v8@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@vitest/coverage-v8@npm:3.0.5"
   dependencies:
     "@ampproject/remapping": "npm:^2.3.0"
     "@bcoe/v8-coverage": "npm:^1.0.2"
@@ -1096,12 +1096,12 @@ __metadata:
     test-exclude: "npm:^7.0.1"
     tinyrainbow: "npm:^2.0.0"
   peerDependencies:
-    "@vitest/browser": 3.0.4
-    vitest: 3.0.4
+    "@vitest/browser": 3.0.5
+    vitest: 3.0.5
   peerDependenciesMeta:
     "@vitest/browser":
       optional: true
-  checksum: 10c0/bffa89652d6a10fde188893e16c53885803f6bf3be76bb1b2224050ce00feea056e5f23642b2cc21f37385ec0da88fbfaab098a55ab723d23effc3cd6e54ecd0
+  checksum: 10c0/2b1670bbe7bedbb7eaef28e0e4e6bebc38900934525ff28e7be23ee2f719bae10fd56afd586142a0e97ccb7ae3e098ad56136c990fecb745a9473b1851746ff7
   languageName: node
   linkType: hard
 
@@ -3928,7 +3928,7 @@ __metadata:
     "@tmjssz/jsonresume-theme-even": "npm:^0.4.1"
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^22.10.5"
-    "@vitest/coverage-v8": "npm:3.0.4"
+    "@vitest/coverage-v8": "npm:^3.0.5"
     ansicolor: "npm:^2.0.3"
     commander: "npm:^13.0.0"
     error-html: "npm:^0.3.5"
@@ -3943,7 +3943,7 @@ __metadata:
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
     typescript-eslint: "npm:^8.19.1"
-    vitest: "npm:^3.0.3"
+    vitest: "npm:^3.0.5"
   bin:
     resumefy: bin/resumefy.js
   languageName: unknown
@@ -4760,7 +4760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^3.0.3":
+"vitest@npm:^3.0.5":
   version: 3.0.5
   resolution: "vitest@npm:3.0.5"
   dependencies:


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to add a new badge and updates to the `package.json` file to upgrade several dependencies.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7): Added a new Dependabot badge to indicate that Dependabot is enabled for the repository.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L63-R71): Upgraded `@vitest/coverage-v8` from version `3.0.4` to `^3.0.5`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L63-R71): Upgraded `vitest` from version `^3.0.3` to `^3.0.5`.