### PR TITLE
refactor(tests): fix mocks

### DIFF
--- a/src/browser/ResumePage.test.ts
+++ b/src/browser/ResumePage.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { TimeoutError, type Page } from 'puppeteer'
-import fsPromises from 'fs/promises'
+import { writeFile } from 'fs/promises'
 import { ResumePage } from './ResumePage'
 import { log } from '../cli/log'
 import { ResumeBrowser } from './ResumeBrowser'
 import * as menu from './menu'
 
-vi.mock('fs/promises')
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn(),
+}))
 
 vi.mock('../cli/log', () => ({
   log: {
@@ -26,7 +28,6 @@ describe('ResumePage', () => {
 
   const htmlMock = '<html></html>'
 
-  const writeFileSpy = vi.spyOn(fsPromises, 'writeFile')
   const menuSpy = vi.spyOn(menu, 'menu')
 
   let resumePage: ResumePage
@@ -39,7 +40,7 @@ describe('ResumePage', () => {
     page.exposeFunction.mockResolvedValue(undefined)
     page.evaluate.mockResolvedValue(undefined)
 
-    writeFileSpy.mockImplementation(() => Promise.resolve())
+    vi.mocked(writeFile).mockImplementation(() => Promise.resolve())
     page.pdf.mockResolvedValue(undefined)
     menuSpy.mockImplementation((fn) => () => {
       fn()
@@ -73,7 +74,7 @@ describe('ResumePage', () => {
       const dir = './test/dir'
       const name = 'test-file'
       await resumePage.html(dir, name)
-      expect(writeFileSpy).toHaveBeenCalledWith('test/dir/test-file.html', htmlMock)
+      expect(writeFile).toHaveBeenCalledWith('test/dir/test-file.html', htmlMock)
     })
   })
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,22 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import * as render from './render'
-import * as init from './init'
-import * as validate from './validate'
+import { render } from './render'
+import { init } from './init'
+import { validate } from './validate'
 import { cli } from './index'
 
-vi.mock('./render')
-vi.mock('./init')
-vi.mock('./validate')
+vi.mock('./render', () => ({
+  render: vi.fn(),
+}))
+vi.mock('./init', () => ({
+  init: vi.fn(),
+}))
+vi.mock('./validate', () => ({
+  validate: vi.fn(),
+}))
 
 describe('CLI', () => {
-  const renderSpy = vi.spyOn(render, 'render')
-  const initSpy = vi.spyOn(init, 'init')
-  const validateSpy = vi.spyOn(validate, 'validate')
-
   beforeEach(() => {
-    renderSpy.mockResolvedValue()
-    initSpy.mockResolvedValue()
-    validateSpy.mockResolvedValue()
+    vi.mocked(render).mockResolvedValue(undefined)
+    vi.mocked(init).mockResolvedValue(undefined)
+    vi.mocked(validate).mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -29,26 +31,26 @@ describe('CLI', () => {
 
     it('should call render as default command', () => {
       cli.parse(['node', 'resumefy', 'myresume.json'])
-      expect(renderSpy).toHaveBeenCalledTimes(1)
-      expect(renderSpy).toHaveBeenCalledWith('myresume.json', defaultOptions, renderCommand)
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render).toHaveBeenCalledWith('myresume.json', defaultOptions, renderCommand)
     })
 
     it('should call render with "resume.json" as default if no file name is passed', () => {
       cli.parse(['node', 'resumefy', 'render'])
-      expect(renderSpy).toHaveBeenCalledTimes(1)
-      expect(renderSpy).toHaveBeenCalledWith('resume.json', defaultOptions, renderCommand)
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render).toHaveBeenCalledWith('resume.json', defaultOptions, renderCommand)
     })
 
     it.each(['-d', '--outDir'])('should call render with passed outDir option using `%s`', (outDirOption) => {
       cli.parse(['node', 'resumefy', 'render', 'myresume.json', outDirOption, 'output'])
-      expect(renderSpy).toHaveBeenCalledTimes(1)
-      expect(renderSpy).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, outDir: 'output' }, renderCommand)
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, outDir: 'output' }, renderCommand)
     })
 
     it.each(['-t', '--theme'])('should call render with passed theme option using `%s`', (themeOption) => {
       cli.parse(['node', 'resumefy', 'render', 'myresume.json', themeOption, 'jsonresume-theme-even'])
-      expect(renderSpy).toHaveBeenCalledTimes(1)
-      expect(renderSpy).toHaveBeenCalledWith(
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render).toHaveBeenCalledWith(
         'myresume.json',
         { ...defaultOptions, theme: 'jsonresume-theme-even' },
         renderCommand,
@@ -57,20 +59,20 @@ describe('CLI', () => {
 
     it.each(['-p', '--port'])('should call render with passed port option using `%s`', (portOption) => {
       cli.parse(['node', 'resumefy', 'render', 'myresume.json', portOption, '3333'])
-      expect(renderSpy).toHaveBeenCalledTimes(1)
-      expect(renderSpy).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, port: '3333' }, renderCommand)
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, port: '3333' }, renderCommand)
     })
 
     it.each(['-w', '--watch'])('should call render with passed watch option using `%s`', (watchOption) => {
       cli.parse(['node', 'resumefy', 'render', 'myresume.json', watchOption])
-      expect(renderSpy).toHaveBeenCalledTimes(1)
-      expect(renderSpy).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, watch: true }, renderCommand)
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, watch: true }, renderCommand)
     })
 
     it('should call render with passed headless option', () => {
       cli.parse(['node', 'resumefy', 'render', 'myresume.json', '--headless'])
-      expect(renderSpy).toHaveBeenCalledTimes(1)
-      expect(renderSpy).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, headless: true }, renderCommand)
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render).toHaveBeenCalledWith('myresume.json', { ...defaultOptions, headless: true }, renderCommand)
     })
   })
 
@@ -79,20 +81,20 @@ describe('CLI', () => {
 
     it('should call init with "resume.json" as default if no file name is passed', () => {
       cli.parse(['node', 'resumefy', 'init'])
-      expect(initSpy).toHaveBeenCalledTimes(1)
-      expect(initSpy).toHaveBeenCalledWith('resume.json', {}, initCommand)
+      expect(init).toHaveBeenCalledTimes(1)
+      expect(init).toHaveBeenCalledWith('resume.json', {}, initCommand)
     })
 
     it('should call init with passed file name', () => {
       cli.parse(['node', 'resumefy', 'init', 'myresume.json'])
-      expect(initSpy).toHaveBeenCalledTimes(1)
-      expect(initSpy).toHaveBeenCalledWith('myresume.json', {}, initCommand)
+      expect(init).toHaveBeenCalledTimes(1)
+      expect(init).toHaveBeenCalledWith('myresume.json', {}, initCommand)
     })
 
     it.each(['-t', '--theme'])('should call render with passed theme option using `%s`', (themeOption) => {
       cli.parse(['node', 'resumefy', 'init', 'myresume.json', themeOption, 'jsonresume-theme-even'])
-      expect(initSpy).toHaveBeenCalledTimes(1)
-      expect(initSpy).toHaveBeenCalledWith('myresume.json', { theme: 'jsonresume-theme-even' }, initCommand)
+      expect(init).toHaveBeenCalledTimes(1)
+      expect(init).toHaveBeenCalledWith('myresume.json', { theme: 'jsonresume-theme-even' }, initCommand)
     })
   })
 
@@ -101,14 +103,14 @@ describe('CLI', () => {
 
     it('should call validate with "resume.json" as default if no file name is passed', () => {
       cli.parse(['node', 'resumefy', 'validate'])
-      expect(validateSpy).toHaveBeenCalledTimes(1)
-      expect(validateSpy).toHaveBeenCalledWith('resume.json', {}, validateCommand)
+      expect(validate).toHaveBeenCalledTimes(1)
+      expect(validate).toHaveBeenCalledWith('resume.json', {}, validateCommand)
     })
 
     it('should call validate with passed file name', () => {
       cli.parse(['node', 'resumefy', 'validate', 'myresume.json'])
-      expect(validateSpy).toHaveBeenCalledTimes(1)
-      expect(validateSpy).toHaveBeenCalledWith('myresume.json', {}, validateCommand)
+      expect(validate).toHaveBeenCalledTimes(1)
+      expect(validate).toHaveBeenCalledWith('myresume.json', {}, validateCommand)
     })
   })
 })

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import fsPromises from 'fs/promises'
+import { readFile } from 'fs/promises'
 import { log } from './log'
 import * as validateObject from '../validate/validate'
 import { validate } from './validate'
 
-vi.mock('fs/promises')
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}))
 
 vi.mock('./log', () => ({
   log: {
@@ -17,11 +19,10 @@ describe('validate', () => {
   const filename = 'test-resume.json'
   const mockResumeObject = { basics: { name: 'John Doe' } }
 
-  const readFileSpy = vi.spyOn(fsPromises, 'readFile')
   const validateObjectSpy = vi.spyOn(validateObject, 'validateObject')
 
   beforeEach(() => {
-    readFileSpy.mockResolvedValue(JSON.stringify(mockResumeObject))
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockResumeObject))
     validateObjectSpy.mockReturnValue(true)
   })
 
@@ -31,12 +32,12 @@ describe('validate', () => {
 
   it('should log an error if reading the file fails', async () => {
     const error = new Error('File read error')
-    readFileSpy.mockRejectedValueOnce(error)
+    vi.mocked(readFile).mockRejectedValueOnce(error)
 
     await validate(filename)
 
-    expect(readFileSpy).toHaveBeenCalledTimes(1)
-    expect(readFileSpy).toHaveBeenCalledWith(filename, 'utf-8')
+    expect(readFile).toHaveBeenCalledTimes(1)
+    expect(readFile).toHaveBeenCalledWith(filename, 'utf-8')
 
     expect(validateObjectSpy).not.toHaveBeenCalled()
 
@@ -51,8 +52,8 @@ describe('validate', () => {
 
     await validate(filename)
 
-    expect(readFileSpy).toHaveBeenCalledTimes(1)
-    expect(readFileSpy).toHaveBeenCalledWith(filename, 'utf-8')
+    expect(readFile).toHaveBeenCalledTimes(1)
+    expect(readFile).toHaveBeenCalledWith(filename, 'utf-8')
 
     expect(validateObjectSpy).toHaveBeenCalledTimes(1)
     expect(validateObjectSpy).toHaveBeenCalledWith(mockResumeObject)
@@ -67,8 +68,8 @@ describe('validate', () => {
 
     await validate(filename)
 
-    expect(readFileSpy).toHaveBeenCalledTimes(1)
-    expect(readFileSpy).toHaveBeenCalledWith(filename, 'utf-8')
+    expect(readFile).toHaveBeenCalledTimes(1)
+    expect(readFile).toHaveBeenCalledWith(filename, 'utf-8')
 
     expect(validateObjectSpy).toHaveBeenCalledTimes(1)
     expect(validateObjectSpy).toHaveBeenCalledWith(mockResumeObject)

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,17 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import sampleResume from '@jsonresume/schema/sample.resume.json' with { type: 'json' }
-import fsPromises from 'fs/promises'
+import { writeFile } from 'fs/promises'
 import { init } from './init'
 
-vi.mock('fs/promises')
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn(),
+}))
 
 describe('init', () => {
   const resumeFile = 'test-resume.json'
 
-  const writeFileSpy = vi.spyOn(fsPromises, 'writeFile')
-
   beforeEach(() => {
-    writeFileSpy.mockResolvedValue(undefined)
+    vi.mocked(writeFile).mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -21,7 +21,7 @@ describe('init', () => {
   it('should write sample resume to file without theme', async () => {
     await init(resumeFile)
 
-    expect(writeFileSpy).toHaveBeenCalledWith(resumeFile, JSON.stringify(sampleResume, null, 2))
+    expect(writeFile).toHaveBeenCalledWith(resumeFile, JSON.stringify(sampleResume, null, 2))
   })
 
   it('should write sample resume to file with theme', async () => {
@@ -30,6 +30,6 @@ describe('init', () => {
 
     await init(resumeFile, theme)
 
-    expect(writeFileSpy).toHaveBeenCalledWith(resumeFile, JSON.stringify(expectedResume, null, 2))
+    expect(writeFile).toHaveBeenCalledWith(resumeFile, JSON.stringify(expectedResume, null, 2))
   })
 })


### PR DESCRIPTION
Replaced direct imports of fs/promises with specific functions (writeFile, readFile, mkdir) in multiple test files. Updated mocking strategy to use vi.mocked for better clarity and consistency across tests. This change enhances the readability and maintainability of the test code.